### PR TITLE
fix invalid header issue

### DIFF
--- a/test/hl7_message_test.exs
+++ b/test/hl7_message_test.exs
@@ -142,6 +142,13 @@ defmodule HL7MessageTest do
     assert %HL7.InvalidMessage{} = HL7.Message.new("Bogus message")
   end
 
+  test "An incomplete header passed into Message.new will result in InvalidMessage" do
+    missing_message_type =
+      HL7.Examples.wikipedia_sample_hl7() |> String.replace("ADT^A01^ADT_A01", "")
+
+    assert %HL7.InvalidMessage{} = HL7.Message.new(missing_message_type)
+  end
+
   test "Can search a raw message for a segment name" do
     field_count =
       HL7.Examples.wikipedia_sample_hl7()


### PR DESCRIPTION
An incomplete header passed into Message.new will NOT result in InvalidMessage which is bad.
This fixes that but isn't terribly pretty.

The next PR I'd like to do will replace some of this though, simplify the library, and cause some breaking changes....
(getting rid of Message.raw() and storing data as maps, etc)