### PR TITLE
Remove accept_latin1 option

### DIFF
--- a/lib/hl7/message.ex
+++ b/lib/hl7/message.ex
@@ -11,8 +11,6 @@ defmodule HL7.Message do
 
   `copy: true` -- Will create binary copies while parsing to avoid keeping references.
   `validate_string: true` -- Will generate an `HL7.InvalidMessage` if the source text is not UTF-8 compatible.
-  `accept_latin1: true` -- If used with `validate_string: true`, this will take failed validations and attempt to encode any latin1 as UTF-8.
-                           If used without `validate_string: true`, this will always attempt to encode any latin1 as UTF-8.
   """
   alias HL7.Path
 
@@ -510,17 +508,10 @@ defmodule HL7.Message do
   end
 
   defp validate_text(raw_text, options) do
-    encoded_text =
-      if options[:accept_latin1] == true do
-        :unicode.characters_to_binary(raw_text, :latin1)
-      else
-        raw_text
-      end
-
     validate_string = options[:validate_string] == true
 
-    if !validate_string or String.valid?(encoded_text) do
-      {:ok, encoded_text}
+    if !validate_string or String.valid?(raw_text) do
+      {:ok, raw_text}
     else
       %HL7.InvalidMessage{
         raw: raw_text,

--- a/test/hl7_message_test.exs
+++ b/test/hl7_message_test.exs
@@ -156,14 +156,6 @@ defmodule HL7MessageTest do
     assert %HL7.InvalidMessage{} = HL7.Message.new(latin1_msg, %{validate_string: true})
   end
 
-  test "A message with latin1 data passed into Message.new will result in a valid Message with options `validate_string: true` and `accept_latin1: true`" do
-    latin1_text = <<220, 105, 178>>
-    latin1_msg = HL7.Examples.wikipedia_sample_hl7() |> String.replace("A01", latin1_text)
-
-    assert %HL7.Message{} =
-             HL7.Message.new(latin1_msg, %{validate_string: true, accept_latin1: true})
-  end
-
   test "An incomplete header passed into Message.new will result in InvalidMessage" do
     missing_message_type =
       HL7.Examples.wikipedia_sample_hl7() |> String.replace("ADT^A01^ADT_A01", "")


### PR DESCRIPTION
See #22 for background on the rationale for removal. 