### PR TITLE
Speeds up queries by checking field grammar at runtime

### DIFF
--- a/lib/hl7/field_grammar.ex
+++ b/lib/hl7/field_grammar.ex
@@ -1,9 +1,15 @@
 defmodule HL7.FieldGrammar do
   require Logger
 
+  @type t :: list
+
   @moduledoc false
 
-  @spec to_indices(String.t()) :: list()
+  defmacro sigil_g({:<<>>, _, [term]}, _) do
+    HL7.FieldGrammar.to_indices(term)
+  end
+
+  @spec to_indices(String.t()) :: t()
   def to_indices(schema) when is_binary(schema) do
     use_repeat = String.contains?(schema, "[")
     use_segment = String.contains?(schema, "-")

--- a/test/hl7_query_test.exs
+++ b/test/hl7_query_test.exs
@@ -4,6 +4,7 @@ defmodule HL7QueryTest do
   doctest HL7.Query
   doctest HL7.Message
   import HL7.Query
+  import HL7.FieldGrammar, only: :macros
 
   @wiki HL7.Examples.wikipedia_sample_hl7() |> HL7.Message.new()
   @nist HL7.Examples.nist_immunization_hl7() |> HL7.Message.new()
@@ -214,10 +215,16 @@ defmodule HL7QueryTest do
   test "extract multiple segment parts at once" do
     part = new(@wiki) |> get_parts("OBX-6.2")
     assert part == ["Meter", "Kilogram"]
+
+    part = new(@wiki) |> get_parts(~g{OBX-6.2})
+    assert part == ["Meter", "Kilogram"]
   end
 
   test "extract a segment value from the first sub-selected segment" do
     part = new(@wiki) |> select("PID") |> get_part("11[1].5")
+    assert part == "35209"
+
+    part = new(@wiki) |> select("PID") |> get_part(~g{11[1].5})
     assert part == "35209"
   end
 
@@ -292,6 +299,16 @@ defmodule HL7QueryTest do
       HL7.Examples.nist_immunization_hl7()
       |> select("ZZZ")
       |> replace_parts("3", "no selections to replace")
+      |> to_string()
+
+    assert value == HL7.Examples.nist_immunization_hl7()
+  end
+
+  test "replace with a compiled grammar" do
+    value =
+      HL7.Examples.nist_immunization_hl7()
+      |> select("ZZZ")
+      |> replace_parts(~g{3}, "no selections to replace")
       |> to_string()
 
     assert value == HL7.Examples.nist_immunization_hl7()


### PR DESCRIPTION
Often, the queries we make are not coming from a user's input and are hardcoded by developers. Using a macro to build those queries has two advantages. The first is correctness checking and developer joy. The second is throughput. Third is a small memory decrease.

When grammars are turned into indices, they are parsed from a string into a list. The parsing of the string can fail if the string is not properly formatted. The sigil checks the string format at compile time instead of runtime. That catches errors early and reduces developer mistakes.

Throughput when using precompiled grammars was increased on multiple platforms. I used Benchee on an M1 and M2 Mac. The M1 with a String was 1.29x slower. On the M2, the increase was even better, with the string version being 3.65 times slower.

Memory consumption had a similar benefit. M1 Mac was 1.05x larger on M1 and 2.15x larger on the M2. I was surprised but ran the benchmarks multiple times with similar results.

Further gains could be had by removing the ability to use Strings so that no extra function heads need to be checked.