### PR TITLE
Implement enumerable protocol

### DIFF
--- a/lib/hl7.ex
+++ b/lib/hl7.ex
@@ -308,11 +308,11 @@ defmodule HL7 do
     |> case do
       {:ok, :line} ->
         file_path
-        |> File.stream!([], @buffer_size)
+        |> File.stream!(@buffer_size, [])
 
       {:ok, :mllp} ->
         file_path
-        |> File.stream!([], @buffer_size)
+        |> File.stream!(@buffer_size, [])
         |> HL7.MLLPStream.raw_to_messages()
 
       {:error, reason} ->

--- a/lib/hl7/query.ex
+++ b/lib/hl7/query.ex
@@ -546,16 +546,8 @@ defmodule HL7.Query do
       ["Influenza", "PCV 13", "DTaP-Hep B-IPV"]
 
   """
-
-  @spec map(HL7.Query.t(), function()) :: list()
-  def map(%HL7.Query{selections: selections}, fun) when is_function(fun) do
-    selections
-    |> Enum.filter(fn s -> s.valid end)
-    |> Enum.map(fn s ->
-      query = %HL7.Query{selections: [s]}
-      fun.(query)
-    end)
-  end
+  @spec map(HL7.Query.t(), (HL7.Query.t() -> any())) :: list()
+  defdelegate map(query, fun), to: Enum
 
   @doc """
   Deletes all selections in the query document.


### PR DESCRIPTION
resolves #38 

This pull request implements the enumerable protocol for the HL7.Query struct, allowing us to use the enum module and the for-comprehension for processing selections. 
The implementation works similarly to HL7.Query.map/2, in the sense that it transforms the traversed selections into an HL7.Query struct for further processing by passed functions. In fact, a call to HL7.Query.map/2 and Enum.map/2 should produce the same result.