### PR TITLE
Adding `.tool-versions` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ erl_crash.dump
 # Ignore dialyzer plt and hash files
 /priv/plts/*.plt
 /priv/plts/*.hash
+
+.tool-versions


### PR DESCRIPTION
Resolves #81

Having this file ignored allows us to use `asdf` to easily manage what version of elixir/erlang are used for each project on their machine.

## Testing Instructions
1. Add file `.tool-versions` and put some text in it
2. run `git status` and ensure that this file does not appear indicating changes made