### PR TITLE
Adding `empty?` Predicate to HL7 API

### DIFF
--- a/lib/hl7.ex
+++ b/lib/hl7.ex
@@ -550,7 +550,61 @@ defmodule HL7 do
     end
   end
 
+  @doc """
+  Checks the path provided in the HL7 and returns a boolean based on whether the
+  path is 'empty' or not.
+
+  A path is considered empty if the value returned is an empty string (`""`), `nil`,
+  a map whose nodes only contain `nil` or `""`, an empty list, or list which contains
+  any of the values specified.
+
+  ## Examples
+
+      iex> import HL7
+      iex> hl7 = HL7.Examples.wikipedia_sample_hl7() |> new!()
+      iex> empty?(hl7, ~p"PID-999")
+      true
+
+      iex> import HL7
+      iex> hl7 = HL7.Examples.wikipedia_sample_hl7() |> new!() |> put(~p"PID-2", "")
+      iex> empty?(hl7, ~p"PID-2")
+      true
+
+      iex> import HL7
+      iex> hl7 = HL7.Examples.wikipedia_sample_hl7() |> new!()
+      iex> empty?(hl7, ~p"ZZZ[*]")
+      true
+
+      iex> import HL7
+      iex> hl7 = HL7.Examples.wikipedia_sample_hl7() |> new!() |> put(~p"PID-2", "NOT_EMPTY")
+      iex> empty?(hl7, ~p"PID-2")
+      false
+
+      iex> import HL7
+      iex> hl7 = HL7.Examples.wikipedia_sample_hl7() |> new!()
+      iex> empty?(hl7, ~p"OBX[1]")
+      false
+  """
+
+  @spec empty?(parsed_hl7(), Path.t()) :: boolean()
+  def empty?(hl7, %HL7.Path{} = path) do
+    HL7.get(hl7, path) |> empty_value?()
+  end
+
   # internals
+  defp empty_value?(value) when value in ["", nil], do: true
+
+  defp empty_value?([]), do: true
+
+  defp empty_value?([head | tail]) do
+    with true <- empty_value?(head) do
+      empty_value?(tail)
+    end
+  end
+
+  defp empty_value?(%{} = map), do: empty_value?(Map.values(map))
+
+  defp empty_value?(_), do: false
 
   defp get_max_index(data) when is_map(data) do
     data |> Map.keys() |> Enum.max() |> max(0)

--- a/test/hl7_test.exs
+++ b/test/hl7_test.exs
@@ -833,6 +833,58 @@ defmodule HL7Test do
     end
   end
 
+  describe "HL7.empty?/2" do
+    test "returns true when selecting repetitions that are all empty from multiple segments" do
+      hl7 = new!(@wiki_text)
+
+      assert empty?(hl7, ~p"OBX[*]-999[*]")
+    end
+
+    test "returns false when selecting repetitions that are partially full from multiple segments" do
+      hl7 =
+        new!(@wiki_text <> "\nOBX|3")
+        |> put(~p"OBX[2]-100[1]", "FOO")
+        |> put(~p"OBX[2]-100[2]", "BAR")
+        |> put(~p"OBX[3]-100[2]", "BUZ")
+
+      refute empty?(hl7, ~p"OBX[*]-100[*]")
+    end
+
+    test "returns false when selecting a field which has components that contain data" do
+      hl7 = new!(@wiki_text) |> put(~p"PID-20.1", "FOO") |> put(~p"PID-20.2", "BUZZ")
+
+      refute empty?(hl7, ~p"PID-20")
+    end
+
+    test "returns true when a field is selected which has a 2nd component that has a 1st sub-component with an empty value" do
+      hl7 = new!(@wiki_text) |> put(~p"PID-20.2.1", "")
+
+      assert empty?(hl7, ~p"PID-20")
+    end
+
+    test "returns true when selecting a single segment that does not exist" do
+      hl7 = new!(@wiki_text)
+
+      assert empty?(hl7, ~p"ZZZ")
+    end
+
+    test "returns true when selecting empty field from multiple segments" do
+      hl7 = new!(@wiki_text)
+
+      assert empty?(hl7, ~p"OBX[*]-999")
+    end
+
+    test "returns false when only some values are found in a field across multiple segments" do
+      hl7 =
+        new!(@wiki_text <> "\nOBX|3")
+        |> put(~p"OBX[1]-20", "")
+        |> put(~p"OBX[2]-20", "SOMETHING")
+        |> put(~p"OBX[3]-20", "")
+
+      refute empty?(hl7, ~p"OBX[*]-20")
+    end
+  end
+
   test "Can open a good mllp message from file stream using file type inference" do
     filepath = tmp_path("wiki.hl7")
     wiki_hl7 = HL7.Examples.wikipedia_sample_hl7()


### PR DESCRIPTION
Resolves #76 

There are often times when consumers need to know whether the path they are selecting from the HL7 contains data. This concept of the data returned being "empty" is currently undefinded in the HL7 library and is left up to interpretation of the users.

This provides an implementaiton for determining if a given path is empty of data or not.

## Testing Instructions

1. Start application `iex -S mix`
2. Create an HL7 message for testing:

```elixir
import HL7

hl7 = HL7.Examples.wikipedia_sample_hl7() |> new!()
```

3. Check if a populated field returns false:

```elixir
empty?(hl7, ~p"MSH-4")
```

4. Check if a non-existant field returns true:

```elixir
empty?(hl7, ~p"PID-999")
```

5. Check if a field with an empty string as a value returns true:

```elixir
hl7 |> put(~p"PID-20", "") |> empty?(~p"PID-20")
```

6. Check if a non-existant segment returns true:

```elixir
empty?(hl7, ~p"ZZZ")
```

7. Check if an existant segment returns false:

```elixir
empty?(hl7, ~p"MSH")
```

8. Check if returning empty repetitions returns true

```elixir
empty?(hl7, ~p"OBX[*]-999[*]")
```

9. Check any other condition you can think of. Also review the unit tests and ensure enough conditions are tested