### PR TITLE
Fix updating field with empty repetitions

### DIFF
--- a/lib/hl7.ex
+++ b/lib/hl7.ex
@@ -575,11 +575,28 @@ defmodule HL7 do
   end
 
   defp to_map(acc, index, [h | t]) do
-    case to_map(h) do
-      "" -> acc
-      v -> Map.put(acc, index, v)
+    case {to_map(h), t} do
+      # Preserve empty strings when followed by more empty strings
+      # This maintains proper indexing for cases like ["", ""] (two empty repetitions)
+      {"", [_ | _]} ->
+        if list_has_only_empty_strings?(t) do
+          Map.put(acc, index, "")
+        else
+          acc
+        end
+
+      # Skip only if a truly trailing empty value
+      {"", []} ->
+        acc
+
+      {v, _} ->
+        Map.put(acc, index, v)
     end
     |> to_map(index + 1, t)
+  end
+
+  defp list_has_only_empty_strings?(list) do
+    Enum.all?(list, &(to_map(&1) == ""))
   end
 
   defp do_to_list(hl7_map_data) when is_binary(hl7_map_data) do
@@ -703,6 +720,10 @@ defmodule HL7 do
 
   defp resolve_placement_value(_field_data = nil, {_fun}, path) do
     raise KeyError, message: "HL7.Path #{inspect(path)} could not be found"
+  end
+
+  defp resolve_placement_value(field_data, {fun}, path) when is_list(field_data) do
+    field_data |> Enum.map(fun) |> format_final_value(path)
   end
 
   defp resolve_placement_value(field_data, {fun}, path) do

--- a/lib/hl7.ex
+++ b/lib/hl7.ex
@@ -596,7 +596,7 @@ defmodule HL7 do
   end
 
   defp list_has_only_empty_strings?(list) do
-    Enum.all?(list, &(to_map(&1) == ""))
+    Enum.all?(list, &(&1 == ""))
   end
 
   defp do_to_list(hl7_map_data) when is_binary(hl7_map_data) do

--- a/test/hl7_test.exs
+++ b/test/hl7_test.exs
@@ -681,6 +681,18 @@ defmodule HL7Test do
       msg = @wiki_text |> new!()
       assert_raise KeyError, fn -> update!(msg, ~p"PID-11[*].2", fn c -> c <> "2" end) end
     end
+
+    test "can update! preserving empty repetitions" do
+      msg =
+        @wiki_text
+        |> String.replace("PID|||", "PID||~|")
+        |> new!()
+
+      assert ["", ""] == get(msg, ~p"PID-2[*]")
+
+      updated_msg = msg |> update!(~p"PID-2[*]", &Function.identity/1)
+      assert ["", ""] == get(updated_msg, ~p"PID-2[*]")
+    end
   end
 
   describe "HL7 inspect protocol" do


### PR DESCRIPTION
Resolves #87 

Considering the following test cases should also be added:

1. `PID||~~|` - three empty repetitions 
2. `PID||~~VALUE|` -  two empty repetitions followed by a value 
3. `PID||VALUE~~|` -  a value followed by two empty repetitions 
4. `PID||VALUE1~~VALUE2|` -  two values separated by an empty repetition 
5. `PID||~VALUE~|` - a value surrounded by empty repetitions

Thoughts? 